### PR TITLE
Improve rate limit handling

### DIFF
--- a/src/components/RsvpComponent.js
+++ b/src/components/RsvpComponent.js
@@ -136,7 +136,25 @@ export default class RsvpComponent extends React.Component {
           minWidth: '466px', minHeight: 'calc(100vh - 36px)',
           pointerEvents: this.state.loading ? 'none' : 'auto'
       }}>
-        <div className={this.state.loading ? 'overlay' : ''} ></div>
+        {
+          this.state.loading && <>
+            <div className='overlay' >
+              <div style={{
+                position: 'absolute',
+                left: 'calc(50% - 200px)',
+                top: '30%',
+                borderRadius: '20px',
+                backgroundColor: 'white',
+                width: '400px',
+                height: '150px'
+              }}>
+                <h1 style={{margin: '2rem'}}>
+                  Loading, please be patient
+                </h1>
+              </div>
+            </div>
+          </>
+        }
         <Header />
         <br />
         <SearchGroupsUsingButtons label="Search Group" />

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,16 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+.overlay {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.5);
+  z-index: 2;
+  cursor: pointer;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { createLogger } from 'redux-logger'
 import { Provider } from 'react-redux'
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import Routes from './Router/Routes'
+import './index.css';
 
 // import * as serviceWorker from './serviceWorker';
 

--- a/src/revamp.js
+++ b/src/revamp.js
@@ -87,7 +87,7 @@ export const fetchSpecificGroupMeetup = (token, additionalParams, groupName,hist
   meetupConfig.params = {...additionalParams, ...meetupConfig.params}
   
   return axios(meetupConfig)
-  .then(res => { console.log(res.data.results); return res.data.results; })
+  .then(res => { return res.data.results; })
   .catch(err => { decideErrorRedirect(err, history)} )
 }
 
@@ -122,9 +122,11 @@ export const rsvp = (token, id, attendValue,history) => {
       "Accept": "*/*"
     }
   };
-  return axios(config)
-  .then(res => { return res})
-  .catch(err => { decideErrorRedirect(err, history)} )
+  return axios(config).then(res => {
+    return res
+  })
+  .catch(err => {
+    decideErrorRedirect(err, history)} )
 }
 
     // case LOAD_DATA:


### PR DESCRIPTION
## It could be better, (made faster)

Make 1 request, then 28 requests made concurrently settled in a promiseAll then the setTimeout on the delay required.
chunking the remaining list into the recursive call. 

I could even do list number divided by 30 and tell them how many pages remain.

But that is for another day.

## How it works:
Look at the response headers, which tell  
1) the rate limit remaining value
2) the seconds until the rate limit resets
```javascript
const res = await rsvp(this.props.session.accessToken, uniqmeetup.id, attendValue, this.props.history);
res.headers["x-ratelimit-remaining"]
Number( res.headers["x-ratelimit-reset"] )
```
